### PR TITLE
Prevent Tailwind reference errors on static pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/about.html
+++ b/about.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/blog.html
+++ b/blog.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/contact.html
+++ b/contact.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/documentation.html
+++ b/documentation.html
@@ -8,19 +8,21 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/equipment.html
+++ b/equipment.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/events.html
+++ b/events.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/gallery.html
+++ b/gallery.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/home-alt.html
+++ b/home-alt.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/index.html
+++ b/index.html
@@ -9,19 +9,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/instructors.html
+++ b/instructors.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }

--- a/lessons.html
+++ b/lessons.html
@@ -10,19 +10,21 @@
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    fontFamily: {
-                        'inter': ['Inter', 'sans-serif'],
-                        'playfair': ['Playfair Display', 'serif'],
-                    },
-                    colors: {
-                        'ocean-blue': '#0077be',
-                        'aqua': '#00bcd4',
-                        'sand': '#f5f1eb',
-                        'sunset': '#ff6b35',
-                        'wave': '#4dd0e1',
+        if (typeof tailwind !== 'undefined') {
+            tailwind.config = {
+                theme: {
+                    extend: {
+                        fontFamily: {
+                            'inter': ['Inter', 'sans-serif'],
+                            'playfair': ['Playfair Display', 'serif'],
+                        },
+                        colors: {
+                            'ocean-blue': '#0077be',
+                            'aqua': '#00bcd4',
+                            'sand': '#f5f1eb',
+                            'sunset': '#ff6b35',
+                            'wave': '#4dd0e1',
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Guard Tailwind configuration on every HTML page to avoid `tailwind` reference errors
- Ignore build artifacts and node modules in git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03be3098483289d9bb8263033e687