### PR TITLE
Fix Tailwind initialization and replace favicon images with base64 assets

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Us - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation (same as homepage) -->

--- a/blog.html
+++ b/blog.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blog - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/contact.html
+++ b/contact.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact & Booking - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/documentation.html
+++ b/documentation.html
@@ -6,10 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AquaWind Template Documentation</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -26,8 +27,9 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="font-inter bg-gray-50">
     <div class="max-w-4xl mx-auto px-4 py-12">

--- a/equipment.html
+++ b/equipment.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Equipment Rental - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/events.html
+++ b/events.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Events - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/gallery.html
+++ b/gallery.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gallery - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/home-alt.html
+++ b/home-alt.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AquaWind Kitesurfing - Alternative Home</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/index.html
+++ b/index.html
@@ -5,12 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AquaWind Kitesurfing - Learn, Ride, Soar</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -27,8 +26,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/instructors.html
+++ b/instructors.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Our Instructors - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->

--- a/lessons.html
+++ b/lessons.html
@@ -6,12 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lessons & Courses - AquaWind Kitesurfing</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3NQQEAAATAQJTWTjYl+N0C7DJ64rN6vQMAAAAAAAAAAIDDFjCIAXXyCAPWAAAAAElFTkSuQmCC">
+    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkKN/HQApgIkn1qIZRDUNKAwDjZQFVUW83wQAAAABJRU5ErkJggg==">
     <script>
-        if (typeof tailwind !== 'undefined') {
-            tailwind.config = {
+        window.tailwind = {
+            config: {
                 theme: {
                     extend: {
                         fontFamily: {
@@ -28,8 +27,11 @@
                     }
                 }
             }
-        }
+        };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
 </head>
 <body class="font-inter">
     <!-- Navigation -->


### PR DESCRIPTION
## Summary
- Initialize Tailwind via `window.tailwind` before loading CDN to prevent runtime `tailwind` errors
- Embed favicon images as base64 data URIs, removing binary files from the repo

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03f9aff1083288aff1c30ab3e2191